### PR TITLE
Fix for recipient cart -- unable to remove a need

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
-# protect_from_forgery with: :exception
-# protect_from_forgery with: :null_session
+  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
   before_action :set_cart
   helper_method :current_user, :set_redirect, :current_admin?, :current_user_guest
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'application' %>
+    <% csrf_meta_tags %>
     <!-- Bootstrap Style CDN -->
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>


### PR DESCRIPTION
Real fix for being unable to remove a need from recipient cart.  Remove the temp fix.
