### PR TITLE
Add link to navigate back to recipient's 'store'

### DIFF
--- a/app/helpers/needs_helper.rb
+++ b/app/helpers/needs_helper.rb
@@ -24,7 +24,7 @@ module NeedsHelper
   def grant_need(id)
     need_type = NeedType.find(id)
     if @recipient.needs.exists?(slug: need_type.slug)
-      "#{need_type.name} is already in #{@recipient.full_name}'s cart."
+      "#{need_type.name} is already on #{@recipient.full_name}'s page. #{link}"
     else
       @recipient.needs.create(name: need_type.name,
                               description: need_type.description,
@@ -34,7 +34,14 @@ module NeedsHelper
                               category: need_type.category,
                               quantity: 1
                               )
-      "#{need_type.name} added to #{@recipient.full_name}'s cart."
+      "#{need_type.name} added to #{@recipient.full_name}'s page. #{link}"
     end
+  end
+
+  def link
+    view_context.link_to(
+      "View page?",
+      admin_recipient_path(username: @recipient.username)
+    )
   end
 end

--- a/spec/features/admin_can_add_recipient_needs_spec.rb
+++ b/spec/features/admin_can_add_recipient_needs_spec.rb
@@ -41,9 +41,9 @@ feature "Admin creates Recipient needs" do
     end
 
     expect(current_path).to eq("/admin/recipients/HarryP/needs")
-    expect(page).to have_content("Sheep added to Harry Potter's cart.")
+    expect(page).to have_content("Sheep added to Harry Potter's page.")
 
-    visit "/admin/recipients/HarryP"
+    click_link "View page?"
 
     expect(page).to have_content("Sheep")
     expect(page).to have_content("Cow")
@@ -87,9 +87,9 @@ feature "Admin creates Recipient needs" do
     end
 
     expect(current_path).to eq("/admin/recipients/HarryP/needs")
-    expect(page).to have_content("Cow is already in Harry Potter's cart.")
+    expect(page).to have_content("Cow is already on Harry Potter's page.")
 
-    visit "/admin/recipients/HarryP"
+    click_link "View page?"
 
     expect(page).to have_content("Cow")
     expect(page).not_to have_content("Sheep")


### PR DESCRIPTION
Noticed there was no easy link for admin to return to recipient 'store' from catalogue.
Fixed it.
