### PR TITLE
Assorted bugs and changes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   protect_from_forgery with: :null_session
   before_action :set_cart
-  helper_method :current_user, :set_redirect, :current_admin?, :current_user_guest
+  helper_method :current_user, :set_redirect, :current_admin?, :current_user_guest, :has_need?
 
   def set_redirect
     if request.referrer == nil
@@ -36,5 +36,9 @@ class ApplicationController < ActionController::Base
 
   def current_admin?
     current_user && current_user.admin?
+  end
+
+  def has_need?(recipient)
+    recipient.needs.any?
   end
 end

--- a/app/views/pages/splash.html.erb
+++ b/app/views/pages/splash.html.erb
@@ -14,7 +14,11 @@
               <hr class="intro-divider">
               <ul class="list-inline intro-social-buttons">
                 <li>
-                <%= link_to "Donate", users_path, class: "btn btn-default btn-lg" %>
+                  <% if current_user && current_user.recipient? %>
+                    <%= link_to "Profile", user_path, class: "btn btn-primary" %>
+                  <% else %>
+                    <%= link_to "Donate", users_path, class: "btn btn-primary" %>
+                  <% end %>
                 </li>
               </ul>
             </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -9,21 +9,23 @@
     </div>
     <div class="thumbsize">
         <% @recipients.each do |recipient| %>
-        <div class="another">
-          <div class="boxy">
-            <div class="pictureframe">
-              <%= image_tag recipient.image_url, class: "thumbsize-pic" %>
+          <% if has_need?(recipient) %>
+            <div class="another">
+              <div class="boxy">
+                <div class="pictureframe">
+                  <%= image_tag recipient.image_url, class: "thumbsize-pic" %>
+                </div>
+                <div class="recip-info">
+                  <h3><%= link_to recipient.full_name, recipient_path(recipient.username) %></h3>
+                  <ul>
+                    <li>Country: <%= recipient.country %></li>
+                    <li>About: <%= recipient.description %></li>
+                    <li>Total Need: <%= number_to_currency(recipient.total) %></li>
+                  </ul>
+                </div>
+              </div>
             </div>
-            <div class="recip-info">
-                <h3><%= link_to recipient.full_name, recipient_path(recipient.username) %></h3>
-              <ul>
-                <li>Country: <%= recipient.country %></li>
-                <li>About: <%= recipient.description %></li>
-                <li>Total Need: <%= number_to_currency(recipient.total) %></li>
-              </ul>
-            </div>
-          </div>
-        </div>
           <% end %>
+        <% end %>
     </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,13 +29,6 @@ Rails.application.routes.draw do
   get "/:username", to: "users#recipient", as: :recipient
   patch "/:username/needs/:slug", to: "donations#update", as: :donate_user_need
 
-  # get "/admin/need_types", to: "admin/need_types#index"
-  # post "/admin/need_types", to: "admin/need_types#create"
-  # get "/admin/need_types/new", to: "admin/need_types#new"
-  # get "/admin/need_types/:id/edit", to: "admin/need_types#edit", as: "admin/need"
-  # get "/admin/need_types/:id", to: "admin/need_types#show"
-  # patch "/admin/need_types/:id", to: "admin/need_types#update"
-  # put "/admin/need_types/:id", to: "admin/need_types#update"
   delete "/admin/need_types/:id", to: "admin/need_types#destroy", as: "admin/need_type/delete"
 
   delete "/admin/users/:id", to: "admin/users#destroy", as: "admin/user/delete"
@@ -58,27 +51,4 @@ Rails.application.routes.draw do
   get "/admin/profile/:id", to: "admin/profiles#show", as: "admin/profile/show"
 
   get "/*page", to: "errors#not_found"
-
-  # get "/items", to: "items#index"
-  # get "/items/:id", to: "items#show", as: "item"
-  #
-  # get "/users/new", to: "users#new", as: "new_user"
-  # post "/users", to: "users#create", as: "users"
-  #
-  # post "/cart_items", to: "cart_items#create"
-  # patch "/cart_items/:id", to: "cart_items#update", as: "cart_item"
-  # put "/cart_items/:id", to: "cart_items#update"
-  # delete "/cart_items/:id", to: "cart_items#destroy"
-  #
-  # get "/donations", to: "donations#index"
-  # post "/donations", to: "donations#create"
-  #
-  #
-  # get "admin/users/:id", to: "admin/users#show", as: "admin_user"
-  #
-  # get "/donation", to: "donations#show"
-  # get "/dashboard", to: "users#show"
-  # get "/cart", to: "cart_items#index"
-
-  # resources :needs, only: [:index]
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,7 @@
 require 'faker'
 
-basic_needs_list = ["auto_maintenance.png",
+basic_needs_list = [
+  "auto_maintenance.png",
   "basic_farming_tools.png",
   "bicycle.png",
   "business_cell_phone.png",
@@ -104,7 +105,7 @@ basic_needs_list.each do |a|
   NeedType.create(
   name: a.sub(/\.\w+\z/, "").gsub("_", " ").split.map {|name| name.capitalize}.join(" "),
   description: Faker::Lorem.paragraph(9, false, 2),
-  cost: Faker::Commerce.price,
+  cost: Faker::Number.number(2),
   category_id: Category.find_or_create_by(name: "basic needs").id,
   image_url: a )
 end
@@ -113,7 +114,7 @@ animal_needs_list.each do |a|
   NeedType.create(
   name:a.sub(/\.\w+\z/, "").gsub("_", " ").split.map {|name| name.capitalize}.join(" "),
   description: Faker::Lorem.paragraph(9, false, 2),
-  cost: Faker::Commerce.price,
+  cost: Faker::Number.number(2),
   category_id: Category.find_or_create_by(name: "animals").id,
   image_url: a )
 end
@@ -122,7 +123,7 @@ farming_needs_list.each do |a|
   NeedType.create(
   name:a.sub(/\.\w+\z/, "").gsub("_", " ").split.map {|name| name.capitalize}.join(" "),
   description: Faker::Lorem.paragraph(9, false, 2),
-  cost: Faker::Commerce.price,
+  cost: Faker::Number.number(2),
   category_id: Category.find_or_create_by(name: "farming").id,
   image_url: a )
 end
@@ -131,7 +132,7 @@ health_needs_list.each do |a|
   NeedType.create(
   name:a.sub(/\.\w+\z/, "").gsub("_", " ").split.map {|name| name.capitalize}.join(" "),
   description: Faker::Lorem.paragraph(9, false, 2),
-  cost: Faker::Commerce.price,
+  cost: Faker::Number.number(2),
   category_id: Category.find_or_create_by(name: "health").id,
   image_url: a )
 end
@@ -203,19 +204,30 @@ admins_list = [
 ]
 
 User.create(first_name: "Mike", last_name: "Dao", email: "mike.dao@gmail.com", password: "password", role: 1, username: "MikeDao", country: "US", image_url: "global_admin.png")
+User.create(first_name: "Josh", last_name: "Mejia", email: "recipient@gmail.com", password: "password", role: 2, username: "JoshMejia", country: "US", image_url: "global_admin.png")
+User.create(first_name: "Nate", last_name: "Allen", email: "donor@gmail.com", password: "password", role: 0, username: "NateAllen", country: "US", image_url: "global_admin.png")
 
-recipients_list.each do |a|
+recipients_list.each_with_index do |a, i|
+  need = NeedType.find(i+1)
   User.create(
-  first_name: Faker::Name.first_name,
-  last_name: Faker::Name.last_name,
-  email: Faker::Internet.safe_email,
-  city: Faker::Address.city,
-  country: Faker::Address.country,
-  username: "#{Faker::Name.first_name}-#{Faker::Name.last_name}",
-  password: Faker::Internet.password,
-  role: 2,
-  description: Faker::Lorem.paragraph(6, false, 1),
-  image_url: a )
+    first_name: Faker::Name.first_name,
+    last_name: Faker::Name.last_name,
+    email: Faker::Internet.safe_email,
+    city: Faker::Address.city,
+    country: Faker::Address.country,
+    username: "#{Faker::Name.first_name}-#{Faker::Name.last_name}",
+    password: Faker::Internet.password,
+    role: 2,
+    description: Faker::Lorem.paragraph(6, false, 1),
+    image_url: a ).needs.create(
+      name: need.name,
+      description: need.description,
+      cost: need.cost,
+      image_url: need.image_url,
+      slug: need.slug,
+      category: need.category,
+      quantity: 1
+      )
 end
 
 donors_list.each do |a|

--- a/spec/features/visitor_clicks_donate_spec.rb
+++ b/spec/features/visitor_clicks_donate_spec.rb
@@ -1,16 +1,19 @@
 require "rails_helper"
 
 feature "visitor sees the recipients page" do
-  scenario "clicks donate and sees recipients" do
-    user1, user2 = create_list(:user, 2, role: 2)
+  scenario "they see only the recipients with needs" do
+    need = create(:need)
+    user1 = create(:user, role: 2, first_name: "Jim", country: "Rwanda")
+    user2 = create(:user, role: 2, first_name: "Jane", country: "Botswana")
+    user1.needs = [need]
 
     visit root_path
     click_link "Donate"
 
-    expect(page).to have_content(user1.first_name.capitalize)
-    expect(page).to have_content(user1.country)
+    expect(page).to have_content("Jim")
+    expect(page).to have_content("Rwanda")
 
-    expect(page).to have_content(user2.first_name.capitalize)
-    expect(page).to have_content(user2.country)
+    expect(page).to_not have_content("Jane")
+    expect(page).to_not have_content("Botswana")
   end
 end


### PR DESCRIPTION
Recipients without needs are no longer visible on the recipients index
Button on splash now directs to profile if current_user is a recipient
Added associated needs to seeded recipients
Added default Recipient and Donor users for demonstration
Changed tests to account for all this (passing after merging from master)

closes #118 
closes #20 
